### PR TITLE
feat: add tiredness_details fix #40

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -296,6 +296,11 @@ function App() {
       nextStep = 5
     }
 
+    // when not tired, skip to cough
+    if (tiredness === false) {
+      nextStep = 7
+    }
+
     if (height && weight) {
       nextStep = 11
     }
@@ -314,7 +319,7 @@ function App() {
     }
 
     setStep(nextStep)
-  }, [step, ageRange, fever, height, weight, riskFactors, riskFactorsRadios, postalCode])
+  }, [step, ageRange, fever, height, weight, riskFactors, riskFactorsRadios, postalCode, tiredness])
 
   // Orderered steps
   const steps = [

--- a/pages/index.js
+++ b/pages/index.js
@@ -123,6 +123,7 @@ function App() {
   const [fever, setFever] = useState(false)
   const [temperature, setTemperature] = useState(null)
   const [tiredness, setTiredness] = useState(null)
+  const [tirednessDetails, setTirednessDetails] = useState(null)
   const [cough, setCough] = useState(false)
   const [agueusiaAnosmia, setAgueusiaAnosmia] = useState(false)
   const [soreThroatAches, setSoreThroatAches] = useState(false)
@@ -146,7 +147,8 @@ function App() {
     setMajorSeverityFactorsCount(isMajorSeverityFactor)
     setMinorSeverityFactorsCount(isMinorSeverityFactor)
 
-    setSymptom(value || isSymptom)
+    // the value can be false
+    setSymptom(value !== undefined ? value : isSymptom)
 
     setStep(step => step + 1)
   }, [setSymptomsCount, setPronosticFactorsCount, setMajorSeverityFactorsCount, setMinorSeverityFactorsCount])
@@ -202,16 +204,18 @@ function App() {
         ...riskFactors,
         ...riskFactorsRadios
       },
+      // set false if undefined
       symptoms: {
-        agueusia_anosmia: agueusiaAnosmia,
-        breathlessness,
-        cough,
-        diarrhea,
-        feeding_day: feedingDay,
-        fever,
-        sore_throat_aches: soreThroatAches,
-        temperature_cat: temperature,
-        tiredness
+        agueusia_anosmia: agueusiaAnosmia || false,
+        breathlessness: breathlessness || false,
+        cough: cough || false,
+        diarrhea: diarrhea || false,
+        feeding_day: feedingDay || false,
+        fever: fever || false,
+        sore_throat_aches: soreThroatAches || false,
+        temperature_cat: temperature || false,
+        tiredness: tiredness || false,
+        tiredness_details: tirednessDetails || false
       }
     })
   }
@@ -241,6 +245,7 @@ function App() {
     setFever(false)
     setTemperature(null)
     setTiredness(null)
+    setTirednessDetails(null)
     setCough(false)
     setAgueusiaAnosmia(false)
     setSoreThroatAches(false)
@@ -292,15 +297,15 @@ function App() {
     }
 
     if (height && weight) {
-      nextStep = 10
-    }
-
-    if (riskFactors) {
       nextStep = 11
     }
 
-    if (riskFactorsRadios) {
+    if (riskFactors) {
       nextStep = 12
+    }
+
+    if (riskFactorsRadios) {
+      nextStep = 13
     }
 
     if (postalCode) {
@@ -319,13 +324,14 @@ function App() {
     {step: 3, question: symptomsQuestions.fever, setSymptom: setFever},
     {step: 4, question: symptomsQuestions.temperature, setSymptom: setTemperature},
     {step: 5, question: symptomsQuestions.tiredness, setSymptom: setTiredness},
-    {step: 6, question: symptomsQuestions.cough, setSymptom: setCough},
-    {step: 7, question: symptomsQuestions.agueusia_anosmia, setSymptom: setAgueusiaAnosmia},
-    {step: 8, question: symptomsQuestions.sore_throat_aches, setSymptom: setSoreThroatAches},
-    {step: 9, component: () => <Imc handleHeight={setHeight} handleWeight={setWeight} />},
-    {step: 10, component: () => <RiskFactors handleRiskFactors={handleRiskFactors} />},
-    {step: 11, component: () => <RiskFactorsRadios handleRiskFactors={handleRiskFactorsRadios} />},
-    {step: 12, component: () => <PostalCode handlePostalCode={setPostalCode} />}
+    {step: 6, question: symptomsQuestions.tiredness_details, setSymptom: setTirednessDetails},
+    {step: 7, question: symptomsQuestions.cough, setSymptom: setCough},
+    {step: 8, question: symptomsQuestions.agueusia_anosmia, setSymptom: setAgueusiaAnosmia},
+    {step: 9, question: symptomsQuestions.sore_throat_aches, setSymptom: setSoreThroatAches},
+    {step: 10, component: () => <Imc handleHeight={setHeight} handleWeight={setWeight} />},
+    {step: 11, component: () => <RiskFactors handleRiskFactors={handleRiskFactors} />},
+    {step: 12, component: () => <RiskFactorsRadios handleRiskFactors={handleRiskFactorsRadios} />},
+    {step: 13, component: () => <PostalCode handlePostalCode={setPostalCode} />}
   ]
 
   return (

--- a/symptoms-questions.json
+++ b/symptoms-questions.json
@@ -84,17 +84,36 @@
     ]
   },
   "tiredness": {
-    "title": "Avez-vous une fatigue inhabituelle ces derniers jours vous obligeant à vous reposer plus de la moitiée de la journée ?",
+    "title": "Avez-vous une fatigue inhabituelle ces derniers jours ?",
     "icon": "fa-bed",
     "responses": [
       {
         "label": "Oui",
         "icon": "fa-check",
-        "isMinorSeverityFactor": true
+        "isMinorSeverityFactor": true,
+        "value": true
       },
       {
         "label": "Non",
-        "icon": "fa-times"
+        "icon": "fa-times",
+        "value": false
+      }
+    ]
+  },
+  "tiredness_details": {
+    "title": "Cette fatigue vous oblige-t-elle à vous reposer plus de la moitié de la journée ?",
+    "icon": "fa-bed",
+    "responses": [
+      {
+        "label": "Oui",
+        "icon": "fa-check",
+        "isMajorSeverityFactor": true,
+        "value": true
+      },
+      {
+        "label": "Non",
+        "icon": "fa-times",
+        "value": false
       }
     ]
   },

--- a/symptoms-questions.json
+++ b/symptoms-questions.json
@@ -90,7 +90,6 @@
       {
         "label": "Oui",
         "icon": "fa-check",
-        "isMinorSeverityFactor": true,
         "value": true
       },
       {
@@ -107,7 +106,7 @@
       {
         "label": "Oui",
         "icon": "fa-check",
-        "isMajorSeverityFactor": true,
+        "isMinorSeverityFactor": true,
         "value": true
       },
       {


### PR DESCRIPTION
ajout de l'écran add `tiredness_details``

les symptoms envoyés à l'API sont maintenant à `false` au lieu de `undefined` (ex: cases à cocher)
fix #40